### PR TITLE
Improve LD_FLAGS and CC_FLAGS in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,8 @@ TEST_CPP_FILES = $(filter-out src/main.cc, $(sort $(CPP_FILES) $(wildcard test/*
 OBJ_FILES = $(addprefix obj/,$(notdir $(CPP_FILES:.cc=.o)))
 TEST_OBJ_FILES = $(addprefix obj/,$(notdir $(TEST_CPP_FILES:.cc=.o)))
 
-LD_FLAGS = -lpthread -lgomp -lrt
-CC_FLAGS = -Wall -std=c++11 -O3 -march=native -flto -fopenmp -D_GLIBCXX_PARALLEL
+LD_FLAGS = -fopenmp -flto
+CC_FLAGS = -Wall -std=c++11 -O3 -march=native -flto -D_GLIBCXX_PARALLEL -pthread
 
 # Debug compile and linker flags (remove optimizations and add debugging symbols)
 debug: CC_FLAGS = -Wall -std=c++11 -g


### PR DESCRIPTION
- Remove unneeded -lrt flag
- Use -fopenmp rather than -lopenmp
- Use -pthread rather than -lpthread