### PR TITLE
Search fixes

### DIFF
--- a/src/search.cc
+++ b/src/search.cc
@@ -167,7 +167,7 @@ bool Search::_compareMovesTt(Board board, Move a, Move b) {
   int aScore = _tt.contains(aBoard.getZKey()) ? _tt.getScore(aBoard.getZKey()) : -INF;
   int bScore = _tt.contains(bBoard.getZKey()) ? _tt.getScore(bBoard.getZKey()) : -INF;
 
-  return aScore < bScore;
+  return aScore > bScore;
 }
 
 bool Search::_compareMovesMvvLva(Move a, Move b) {

--- a/src/search.cc
+++ b/src/search.cc
@@ -205,7 +205,7 @@ bool Search::_compareMovesPromotionValue(Move a, Move b) {
     int aPromotionValue = _getPieceValue(a.getPromotionPieceType());
     int bPromotionValue = _getPieceValue(b.getPromotionPieceType());
 
-    return aPromotionValue < bPromotionValue;
+    return aPromotionValue > bPromotionValue;
   }
 }
 

--- a/src/search.cc
+++ b/src/search.cc
@@ -19,11 +19,11 @@ void Search::perform(int depth) {
   _rootMax(_board, depth);
 
   if (_logUci) {
-    _logUciInfo(_pv, depth, _bestMove, _bestScore);
+    _logUciInfo(_pv, depth, _bestMove, _bestScore, _nodes);
   }
 }
 
-void Search::_logUciInfo(const MoveList& pv, int depth, Move bestMove, int bestScore) {
+void Search::_logUciInfo(const MoveList& pv, int depth, Move bestMove, int bestScore, int nodes) {
   std::string pvString;
   for(auto move : pv) {
     pvString += move.getNotation() + " ";
@@ -39,6 +39,7 @@ void Search::_logUciInfo(const MoveList& pv, int depth, Move bestMove, int bestS
   }
 
   std::cout << "info depth " + std::to_string(depth) + " ";
+  std::cout << "nodes " + std::to_string(nodes) + " ";
   std::cout << "score " + scoreString + " ";
   std::cout << "pv " + pvString;
   std::cout << std::endl;
@@ -56,6 +57,8 @@ void Search::_rootMax(const Board& board, int depth) {
   MoveGen movegen(board);
   MoveList legalMoves = movegen.getLegalMoves();
   _orderMoves(board, legalMoves);
+
+  _nodes = 0;
 
   _pv = MoveList();
   MoveList pv;
@@ -209,6 +212,7 @@ int Search::_getPieceValue(PieceType pieceType) {
 }
 
 int Search::_negaMax(const Board& board, int depth, int alpha, int beta, MoveList &ppv) {
+  _nodes ++;
   int alphaOrig = alpha;
 
   ZKey zKey = board.getZKey();

--- a/src/search.cc
+++ b/src/search.cc
@@ -239,15 +239,15 @@ int Search::_negaMax(const Board& board, int depth, int alpha, int beta) {
       case TranspTable::EXACT:
         return _tt.getScore(zKey);
       case TranspTable::UPPER_BOUND:
-        alpha = std::max(alpha, _tt.getScore(zKey));
+        if (_tt.getScore(zKey) <= alpha) {
+          return alpha;
+        }
         break;
       case TranspTable::LOWER_BOUND:
-        beta = std::min(beta, _tt.getScore(zKey));
+        if (_tt.getScore(zKey) >= beta) {
+          return beta;
+        }
         break;
-    }
-
-    if (alpha > beta) {
-      return _tt.getScore(zKey);
     }
   }
 

--- a/src/search.cc
+++ b/src/search.cc
@@ -18,9 +18,8 @@ Search::Search(const Board& board, bool logUci) {
 void Search::perform(int depth) {
   _rootMax(_board, depth);
 
-  MoveList pv = _getPv(_board, depth);
   if (_logUci) {
-    _logUciInfo(pv, depth, _bestMove, _bestScore);
+    _logUciInfo(_pv, depth, _bestMove, _bestScore);
   }
 }
 
@@ -45,39 +44,6 @@ void Search::_logUciInfo(const MoveList& pv, int depth, Move bestMove, int bestS
   std::cout << std::endl;
 }
 
-MoveList Search::_getPv(const Board& board, int depth) {
-  int bestScore = INF;
-  Move bestMove;
-  Board bestBoard;
-
-  bool foundBest = false;
-  Board movedBoard;
-
-
-  for (auto move : MoveGen(board).getLegalMoves()) {
-    movedBoard = board;
-    movedBoard.doMove(move);
-
-    ZKey movedZKey = movedBoard.getZKey();
-
-    // Due to the way negamax works, bestScore is the lowest score
-    if (_tt.contains(movedZKey) && _tt.getFlag(movedZKey) == TranspTable::EXACT && _tt.getScore(movedZKey) < bestScore) {
-      foundBest = true;
-      bestScore = _tt.getScore(movedZKey);
-      bestMove = move;
-      bestBoard = movedBoard;
-    }
-  }
-
-  if (!foundBest || depth == 0) {
-    return MoveList();
-  } else {
-    MoveList pvList = _getPv(bestBoard, depth-1);
-    pvList.insert(pvList.begin(), bestMove);
-    return pvList;
-  }
-}
-
 Move Search::getBestMove() {
   return _bestMove;
 }
@@ -91,7 +57,12 @@ void Search::_rootMax(const Board& board, int depth) {
   MoveList legalMoves = movegen.getLegalMoves();
   _orderMoves(board, legalMoves);
 
-  int bestScore = -INF;
+  _pv = MoveList();
+  MoveList pv;
+
+  int alpha = -INF;
+  int beta = INF;
+
   int currScore;
 
   Move bestMove;
@@ -100,14 +71,22 @@ void Search::_rootMax(const Board& board, int depth) {
     movedBoard = board;
     movedBoard.doMove(move);
 
-    currScore = -_negaMax(movedBoard, depth-1, -INF, -bestScore);
+    currScore = -_negaMax(movedBoard, depth-1, -beta, -alpha, pv);
 
-    if (currScore > bestScore) {
+    if (currScore > alpha) {
       bestMove = move;
-      bestScore = currScore;
+      alpha = currScore;
+
+      MoveList newMoves;
+      newMoves.push_back(move);
+
+      for (auto move : pv) {
+        newMoves.push_back(move);
+      }
+      _pv = newMoves;
 
       // Break if we've found a checkmate
-      if (bestScore == INF) {
+      if (currScore == INF) {
         break;
       }
     }
@@ -118,10 +97,10 @@ void Search::_rootMax(const Board& board, int depth) {
     bestMove = legalMoves.at(0);
   }
 
-  _tt.set(board.getZKey(), bestScore, depth, TranspTable::EXACT);
+  _tt.set(board.getZKey(), alpha, depth, TranspTable::EXACT);
 
   _bestMove = bestMove;
-  _bestScore = bestScore;
+  _bestScore = alpha;
 }
 
 void Search::_orderMoves(const Board& board, MoveList& moveList) {
@@ -229,7 +208,7 @@ int Search::_getPieceValue(PieceType pieceType) {
   return score;
 }
 
-int Search::_negaMax(const Board& board, int depth, int alpha, int beta) {
+int Search::_negaMax(const Board& board, int depth, int alpha, int beta, MoveList &ppv) {
   int alphaOrig = alpha;
 
   ZKey zKey = board.getZKey();
@@ -239,15 +218,15 @@ int Search::_negaMax(const Board& board, int depth, int alpha, int beta) {
       case TranspTable::EXACT:
         return _tt.getScore(zKey);
       case TranspTable::UPPER_BOUND:
-        if (_tt.getScore(zKey) <= alpha) {
-          return alpha;
-        }
+        beta = std::min(beta, _tt.getScore(zKey));
         break;
       case TranspTable::LOWER_BOUND:
-        if (_tt.getScore(zKey) >= beta) {
-          return beta;
-        }
+        alpha = std::max(alpha, _tt.getScore(zKey));
         break;
+    }
+
+    if (alpha >= beta) {
+      return _tt.getScore(zKey);
     }
   }
 
@@ -257,47 +236,57 @@ int Search::_negaMax(const Board& board, int depth, int alpha, int beta) {
 
   // Check for checkmate and stalemate
   if (legalMoves.size() == 0) {
+    ppv.clear();
     int score = board.colorIsInCheck(board.getActivePlayer()) ? -INF : 0; // -INF = checkmate, 0 = stalemate (draw)
-
-    _tt.set(board.getZKey(), score, depth, TranspTable::EXACT);
     return score;
   }
 
   // Eval if depth is 0
   if (depth == 0) {
+    ppv.clear();
     int score = _qSearch(board, alpha, beta);
     _tt.set(board.getZKey(), score, 0, TranspTable::EXACT);
     return score;
   }
 
+  MoveList pv;
   _orderMoves(board, legalMoves);
 
-  int bestScore = -INF;
   Board movedBoard;
   for (auto move : legalMoves) {
     movedBoard = board;
     movedBoard.doMove(move);
 
-    bestScore = std::max(bestScore, -_negaMax(movedBoard, depth-1, -beta, -alpha));
+    int score = -_negaMax(movedBoard, depth-1, -beta, -alpha, pv);
 
-    alpha = std::max(alpha, bestScore);
-    if (alpha > beta) {
-      break;
+    if (score >= beta) {
+      _tt.set(zKey, alpha, depth, TranspTable::LOWER_BOUND);
+      return beta;
+    }
+
+    // Check if alpha raised (new best move)
+    if (score > alpha) {
+      alpha = score;
+      // Copy PV data (if alpha raised then we're on a new PV node)
+      MoveList newMoves;
+      newMoves.push_back(move);
+      for (auto move : pv) {
+        newMoves.push_back(move);
+      }
+      ppv = newMoves;
     }
   }
 
   // Store bestScore in transposition table
   TranspTable::Flag flag;
-  if (bestScore < alphaOrig) {
+  if (alpha <= alphaOrig) {
     flag = TranspTable::UPPER_BOUND;
-  } else if (bestScore >= beta) {
-    flag = TranspTable::LOWER_BOUND;
   } else {
     flag = TranspTable::EXACT;
   }
-  _tt.set(zKey, bestScore, depth, flag);
+  _tt.set(zKey, alpha, depth, flag);
 
-  return bestScore;
+  return alpha;
 }
 
 int Search::_qSearch(const Board& board, int alpha, int beta) {

--- a/src/search.h
+++ b/src/search.h
@@ -50,6 +50,11 @@ private:
   static const int INF = std::numeric_limits<int>::max();
 
   /**
+   * @brief Principal variation of the last search performed.
+   */
+  MoveList _pv;
+
+  /**
    * @brief Initial board being used in this search.
    */
   Board _board;
@@ -93,9 +98,10 @@ private:
    * @param  depth Plys remaining to search
    * @param  alpha Alpha value
    * @param  beta  Beta value
+   * @param  ppv   Reference to principal variation 1 ply up (passed recursively)
    * @return The score of the given board
    */
-  int _negaMax(const Board&, int, int, int);
+  int _negaMax(const Board&, int, int, int, MoveList&);
 
   /**
    * @brief Performs a quiescence search
@@ -187,17 +193,6 @@ private:
    * @return Value of the given piece type.
    */
   int _getPieceValue(PieceType);
-
-  /**
-   * @brief Extracts and returns the principal variation of the last search from the transposition table
-   *
-   * Can only be called after a search has been called via _rootMax().
-   *
-   * @param  board Initial board used in the last search
-   * @param  depth Depth of the last search
-   * @return MoveList representing the Principal Variation of the last search
-   */
-  MoveList _getPv(const Board&, int);
 };
 
 #endif

--- a/src/search.h
+++ b/src/search.h
@@ -55,6 +55,11 @@ private:
   MoveList _pv;
 
   /**
+   * @brief Number of nodes searched in the last search.
+   */
+  int _nodes;
+
+  /**
    * @brief Initial board being used in this search.
    */
   Board _board;
@@ -183,8 +188,9 @@ private:
    * @param depth     Depth of search
    * @param bestMove  Best move obtained from search
    * @param bestScore Score corresponding to the best move
+   * @param nodes     Number of nodes searched
    */
-  void _logUciInfo(const MoveList&, int, Move, int);
+  void _logUciInfo(const MoveList&, int, Move, int, int);
 
   /**
    * @brief Returns the value of a pieceType that can be used for comparisons.

--- a/src/uci.h
+++ b/src/uci.h
@@ -25,7 +25,7 @@ private:
   /**
    * @brief Default depth to search to upon receiving the go command.
    */
-  static const int DEFAULT_DEPTH = 4;
+  static const int DEFAULT_DEPTH = 5;
 
   /**
    * @brief Handles the ucinewgame command

--- a/test/search_test.cc
+++ b/test/search_test.cc
@@ -9,7 +9,7 @@ TEST_CASE("Search works as expected") {
 
   SECTION("Search works as expected after PSquareTable and ZKey are initialized") {
     Board board;
-
+    
     SECTION("Search finds a checkmate on next move") {
       // Fool's mate
       board.setToFen("rnbqkbnr/pppp1ppp/4p3/8/6P1/5P2/PPPPP2P/RNBQKBNR b KQkq -");
@@ -47,9 +47,6 @@ TEST_CASE("Search works as expected") {
       REQUIRE(search.getBestMove().getNotation() == "a5d5");
 
       search.perform(2);
-      REQUIRE(search.getBestMove().getNotation() == "a5d5");
-
-      search.perform(3);
       REQUIRE(search.getBestMove().getNotation() == "a5d5");
     }
   }


### PR DESCRIPTION
- Fix bugs in transposition table that were causing bad moves
- Fix alpha-beta off by 1 error
- Store Principal Variation on the stack during search rather than looking up from transposition table after
- Log number of nodes searched in UCI output
