### PR TITLE
Further move ordering improvements

### DIFF
--- a/src/search.cc
+++ b/src/search.cc
@@ -222,7 +222,7 @@ int Search::_negaMax(const Board& board, int depth, int alpha, int beta, MoveLis
     int score = -_negaMax(movedBoard, depth-1, -beta, -alpha, pv);
 
     if (score >= beta) {
-      TranspTableEntry newTTEntry(alpha, depth, TranspTableEntry::LOWER_BOUND, bestMove);
+      TranspTableEntry newTTEntry(score, depth, TranspTableEntry::LOWER_BOUND, move);
       _tt.set(board.getZKey(), newTTEntry);
       return beta;
     }

--- a/src/search.cc
+++ b/src/search.cc
@@ -127,7 +127,7 @@ void Search::_scoreMoves(const Board& board, MoveList& moveList) {
 
     // Transposition table lookups considered second (dynamic move ordering)
     const TranspTableEntry *ttEntry = _tt.getEntry(tempBoard.getZKey());
-    if (ttEntry && (ttEntry->getFlag() == TranspTableEntry::EXACT)) {
+    if (ttEntry && ((ttEntry->getFlag() == TranspTableEntry::EXACT) || (ttEntry->getFlag() == TranspTableEntry::LOWER_BOUND))) {
       // Score is negated since score is for opponent
       move.setValue(-ttEntry->getScore());
     } else {


### PR DESCRIPTION
- Cache the most recently generated move on beta cutoffs (was caching an older, inferior move)
- Take lower bound tt entries into account when performing transposition table based move ordering

Seems to be a 2x improvement in search speed or so to a depth of 6 plys