### PR TITLE
Optimizations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,9 @@ TEST_OBJ_FILES = $(addprefix obj/,$(notdir $(TEST_CPP_FILES:.cc=.o)))
 LD_FLAGS ?= -pthread -flto
 CC_FLAGS ?= -Wall -std=c++11 -O3 -march=native -flto -pthread -fno-exceptions
 
+# Catch makes use of C++ exceptions, so remove -fno-exceptions when making a test build
+test: CC_FLAGS = -Wall -std=c++11 -O3 -march=native -flto -pthread
+
 # Debug compile and linker flags (remove optimizations and add debugging symbols)
 debug debug-test: CC_FLAGS = -Wall -std=c++11 -g -D__DEBUG__
 debug debug-test: LD_FLAGS = -pthread

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ OBJ_FILES = $(addprefix obj/,$(notdir $(CPP_FILES:.cc=.o)))
 TEST_OBJ_FILES = $(addprefix obj/,$(notdir $(TEST_CPP_FILES:.cc=.o)))
 
 LD_FLAGS ?= -pthread -flto
-CC_FLAGS ?= -Wall -std=c++11 -O3 -march=native -flto -pthread
+CC_FLAGS ?= -Wall -std=c++11 -O3 -march=native -flto -pthread -fno-exceptions
 
 # Debug compile and linker flags (remove optimizations and add debugging symbols)
 debug debug-test: CC_FLAGS = -Wall -std=c++11 -g -D__DEBUG__

--- a/scripts/showbb.py
+++ b/scripts/showbb.py
@@ -1,6 +1,12 @@
 """
-Pretty prints a bitboard to the console given its hex or decimal value from
-argv or stdin.
+Pretty prints a bitboard to the console given a Python expression that
+evaluates to it.
+
+examples:
+
+python showbb.py 45602
+python showbb.py 0x10000
+python showbb.py "((0x1000 >> 3) | 0x20)"
 """
 import sys
 import textwrap
@@ -8,28 +14,24 @@ import textwrap
 FULL_BITBOARD = 0xFFFFFFFFFFFFFFFF  # 64 set bits
 
 
-def print_bb(bb_str):
-    # Handle hex/decimal bitboards
-    if bb_str.startswith("0x"):
-        base = 16
-    else:
-        base = 10
+def print_bb(bb_evalstring):
+    bb = eval(bb_evalstring)
+    print hex(bb)
 
-    if int(bb_str, base).bit_length() > 64:
+    if bb.bit_length() > 64:
         print "WARNING: Bit length is greater than 64, taking lowest 64 bits"
-    bb = bin(int(bb_str, base) & FULL_BITBOARD)
+    bb_str = bin(bb & FULL_BITBOARD)
 
     # Slice off the "0b"
-    bb = bb[2:]
+    bb_str = bb_str[2:]
 
-    bb = bb.replace("0", ".")
-    bb = bb.replace("1", "1")
+    bb_str = bb_str.replace("0", ".")
+    bb_str = bb_str.replace("1", "1")
 
-    if len(bb) < 64:
-        bb = "." * (64 - len(bb)) + bb
+    if len(bb_str) < 64:
+        bb_str = "." * (64 - len(bb_str)) + bb_str
 
-    print bb_str
-    print "\n".join([" ".join(line[::-1]) for line in textwrap.wrap(bb, 8)]) + "\n"
+    print "\n".join([" ".join(line[::-1]) for line in textwrap.wrap(bb_str, 8)]) + "\n"
 
 
 if len(sys.argv) == 1:

--- a/src/attacks.cc
+++ b/src/attacks.cc
@@ -1,7 +1,6 @@
 #include "attacks.h"
 #include "bitutils.h"
 #include <cstring>
-#include <stdexcept>
 
 U64 Attacks::detail::NON_SLIDING_ATTACKS[2][6][64] = {{{0}}};
 U64 Attacks::detail::RAYS[8][64] = {{0}};

--- a/src/attacks.cc
+++ b/src/attacks.cc
@@ -32,7 +32,7 @@ U64 Attacks::getSlidingAttacks(PieceType pieceType, int square, U64 blockers) {
     case QUEEN:
       return detail::_getBishopAttacks(square, blockers) |
           detail::_getRookAttacks(square, blockers);
-    default: throw std::logic_error("Not a sliding piece");
+    default: fatal("Not a sliding piece");
   }
 }
 

--- a/src/bitutils.h
+++ b/src/bitutils.h
@@ -20,7 +20,7 @@ inline int _popLsb(U64 &board) {
 }
 
 /**
- * @brief Returns the number of set bits in the given value.
+ * @brief Returns the number of set bits in the given bitboard.
  *
  * @param  board Value to return number of set bits for
  * @return Number of set bits in value
@@ -30,22 +30,30 @@ inline int _popCount(U64 board) {
 }
 
 /**
- * @brief Returns the index of the LSB in the given bitboard.
+ * @brief Returns the index of the LSB in the given bitboard or -1 if
+ * the bitboard is empty.
  *
  * @param  board Bitboard to get LSB of
  * @return The index of the LSB in the given bitboard.
  */
 inline int _bitscanForward(U64 board) {
+  if (board == ZERO) {
+    return -1;
+  }
   return __builtin_ffsll(board) - 1;
 }
 
 /**
- * @brief Returns the index of the MSB in the given bitboard.
+ * @brief Returns the index of the MSB in the given bitboard or -1 if
+ * the bitboard is empty.
  *
  * @param  board Bitboard to get MSB of
  * @return The index of the MSB in the given bitboard.
  */
 inline int _bitscanReverse(U64 board) {
+  if (board == ZERO) {
+    return -1;
+  }
   return __builtin_clzll(board) + 1;
 }
 

--- a/src/board.cc
+++ b/src/board.cc
@@ -2,8 +2,6 @@
 #include "bitutils.h"
 #include "attacks.h"
 #include <sstream>
-#include <iostream>
-#include <stdexcept>
 
 Board::Board() {
   setToFen("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1");
@@ -193,6 +191,28 @@ std::string Board::getStringRep() const {
     squaresProcessed++;
 
     if ((squaresProcessed % 8 == 0) && (squaresProcessed != 64)) {
+      switch (squaresProcessed / 8) {
+        case 1:
+          stringRep += "        ";
+          stringRep += getActivePlayer() == WHITE ? "White" : "Black";
+          stringRep += " to Move";
+          break;
+        case 2:
+          stringRep += "        Halfmove Clock: ";
+          stringRep += std::to_string(_halfmoveClock);
+          break;
+        case 3:
+          stringRep += "        Castling Rights: ";
+          stringRep += _castlingRights & 1 ? "K" : "";
+          stringRep += _castlingRights & 2 ? "Q" : "";
+          stringRep += _castlingRights & 4 ? "k" : "";
+          stringRep += _castlingRights & 8 ? "q" : "";
+          break;
+        case 4:
+          stringRep += "        En Passant Square: ";
+          stringRep += _enPassant == ZERO ? "-" : Move::indexToNotation(_bitscanForward(_enPassant));
+          break;
+      }
       stringRep += "\n" + std::to_string(--rank) + "  ";
       boardPos -= 16;
     }

--- a/src/board.cc
+++ b/src/board.cc
@@ -63,7 +63,7 @@ U64 Board::getAttacksForSquare(PieceType pieceType, Color color, int square) con
       break;
     case KING: attacks = _getKingAttacksForSquare(square, own);
       break;
-    default: throw std::logic_error("Invalid piece type");
+    default: fatal("Invalid piece type");
   }
 
   return attacks;
@@ -321,7 +321,7 @@ PieceType Board::getPieceAtSquare(Color color, int squareIndex) const {
   else if (square & _pieces[color][KING]) piece = KING;
   else if (square & _pieces[color][QUEEN]) piece = QUEEN;
   else
-    throw std::logic_error((color == WHITE ? std::string("White") : std::string("Black")) +
+    fatal((color == WHITE ? std::string("White") : std::string("Black")) +
         " piece at square " + std::to_string(squareIndex) + " does not exist");
 
   return piece;

--- a/src/board.cc
+++ b/src/board.cc
@@ -217,8 +217,6 @@ void Board::_clearBitBoards() {
   _enPassant = ZERO;
 
   _occupied = ZERO;
-
-  return;
 }
 
 void Board::setToFen(std::string fenString) {

--- a/src/board.h
+++ b/src/board.h
@@ -292,18 +292,16 @@ class Board {
   int _halfmoveClock;
 
   /**
-   * @name Castling rights
+   * @brief Castling rights
    *
    * Stored as 4 bits:
    * - Bit 0 - White kingside
    * - Bit 1 - White queenside
    * - Bit 2 - Black kingside
    * - Bit 3 - Black queenside
-   * @{
    */
   unsigned char _castlingRights;
 
-  /**@}*/
 
   /**
    * @brief Determines if the given square is under attack by the given color.

--- a/src/board.h
+++ b/src/board.h
@@ -14,8 +14,8 @@ class Move;
  *
  * Chess boards are represented using bitboards (of U64 type). Internally, each
  * Board maintains 12 bitboards (one for each piece type and each color), as well
- * as bitboards containing the occupancy, inverse of the occupancy, en passant
- * target square and attackable pieces.
+ * as bitboards containing the occupancy, inverse of the occupancy and en passant
+ * target square.
  *
  */
 class Board {
@@ -262,19 +262,9 @@ class Board {
   U64 _allPieces[2];
 
   /**
-   * @brief Array indexed by [color] of bitboards containing all attackable pieces.
-   */
-  U64 _attackable[2];
-
-  /**
    * @brief Bitboard containing all occupied squares.
    */
   U64 _occupied;
-
-  /**
-   * @brief Bitboard containing all unoccupied squares.
-   */
-  U64 _notOccupied;
 
   /**
    * @brief Bitboard containing the en passant target square.
@@ -312,6 +302,7 @@ class Board {
    * @{
    */
   unsigned char _castlingRights;
+
   /**@}*/
 
   /**
@@ -337,7 +328,7 @@ class Board {
   void _updateCastlingRightsForMove(Move);
 
   /**
-   * @brief Updates the _occupied, _notOccupied and _allPieces bitboards based on the _pieces bitboards.
+   * @brief Updates the _occupied and _allPieces bitboards based on the _pieces bitboards.
    */
   void _updateNonPieceBitBoards();
 
@@ -345,7 +336,8 @@ class Board {
    * @brief Moves a piece between the given squares.
    *
    * Moves the piece from the from square to the to square and updates the
-   * board state appropriately.
+   * board state appropriately. Note that this function is more efficient than
+   * calling _addPiece() and _removePiece() separately.
    *
    * @param color     Color of piece to move
    * @param pieceType Type of piece to move

--- a/src/book.cc
+++ b/src/book.cc
@@ -275,9 +275,9 @@ Move Book::getMove(const Board &board) const {
         return decodeMove(board, moveWeightPair.first);
       }
     }
-    throw std::logic_error("Error in calculating weighted average");
+    fatal("Error in calculating weighted average");
   } else {
-    throw std::logic_error("Position is not in book");
+    fatal("Position is not in book");
   }
 }
 
@@ -380,7 +380,7 @@ Move Book::decodeMove(const Board &board, unsigned short move) {
         break;
       case 4: decodedPromotionPiece = QUEEN;
         break;
-      default: throw std::logic_error("Invalid PolyGlot promotion piece");
+      default: fatal("Invalid PolyGlot promotion piece");
     }
 
     decodedMove.setFlag(Move::PROMOTION);

--- a/src/defs.h
+++ b/src/defs.h
@@ -9,6 +9,8 @@
 #define DEFS_H
 
 #include <limits>
+#include <iostream>
+#include <cstdlib>
 
 /**
  * An unsigned 64 bit integer (A bitboard).
@@ -89,11 +91,24 @@ enum PieceType {
 
 /**
  * @brief Returns the opposite of the given color
+ *
  * @param  color Color to get the opposite of
  * @return WHITE if color == BLACK, BLACK otherwise
  */
 inline Color getOppositeColor(Color color) {
   return color == WHITE ? BLACK : WHITE;
+}
+
+/**
+ * @brief Print the given message to stderr and exit with code 1. Should be used in
+ * unrecoverable situations.
+ *
+ * @param msg Message to print to stderr before exiting
+ */
+[[ noreturn ]]
+inline void fatal(std::string msg) {
+  std::cerr << msg << std::endl;
+  std::exit(1);
 }
 
 /**

--- a/src/uci.cc
+++ b/src/uci.cc
@@ -212,10 +212,10 @@ void loop() {
     else if (token == "printboard") {
       std::cout << std::endl << board.getStringRep() << std::endl;
     } else if (token == "printmoves") {
-      std::cout << std::endl << "Legal moves:" << std::endl;
       for (auto move : MoveGen(board).getLegalMoves()) {
-        std::cout << move.getNotation() << std::endl;
+        std::cout << move.getNotation() << " ";
       }
+      std::cout << std::endl;
     } else if (token == "perft") {
       int depth;
       is >> depth;

--- a/src/uci.cc
+++ b/src/uci.cc
@@ -95,6 +95,8 @@ void go(std::istringstream &is) {
 unsigned long long perft(const Board &board, int depth) {
   if (depth == 0) {
     return 1;
+  } else if (depth == 1) {
+    return MoveGen(board).getLegalMoves().size();
   }
 
   MoveGen movegen(board);

--- a/test/perft_test.cc
+++ b/test/perft_test.cc
@@ -4,14 +4,16 @@
 #include "catch.hpp"
 #include "attacks.h"
 
-int perft(int depth, const Board& board) {
+unsigned long long perft(int depth, const Board& board) {
   if (depth == 0) {
     return 1;
+  } else if (depth == 1) {
+    return MoveGen(board).getLegalMoves().size();
   }
 
   MoveGen movegen(board);
 
-  int nodes = 0;
+  unsigned long long nodes = 0;
   for (auto move : movegen.getLegalMoves()) {
     Board movedBoard = board;
     movedBoard.doMove(move);

--- a/test/rook_movegen_test.cc
+++ b/test/rook_movegen_test.cc
@@ -15,6 +15,7 @@ TEST_CASE("Rook move generation is correct") {
     REQUIRE(movegen.getMoves().size() == 14);
 
     board.setToFen("8/8/8/3r4/8/8/8/8 b - -");
+    movegen.setBoard(board);
     REQUIRE(movegen.getMoves().size() == 14);
   }
 


### PR DESCRIPTION
Implement a variety of small optimizations (and a few small enhancements to existing features).

- Remove incrementally updated bitboards from Board class that could be calculated on the fly quicker
- Take advantage of branch prediction by surrounding code that only needs to be executed from time to time in conditionals
- Add `Board::_movePiece()` and use it instead of `_removePiece()` + `addPiece()` to save a few CPU instructions
- Bulk count leaves in perft calculations
- Don't use C++ exceptions, instead add a new `[[ noreturn ]]` `fatal()` function and compile with -fno-exceptions
- Improve showbb.py script to accept Python expressions rather than only single hex/decimal numbers
- Improve output of printboard and printmoves

Together, these optimizations improve raw perft speed by roughly 10%.